### PR TITLE
Added pagination support for get posts call

### DIFF
--- a/src/main/java/com/example/blogapp/config/Constants.java
+++ b/src/main/java/com/example/blogapp/config/Constants.java
@@ -1,0 +1,10 @@
+package com.example.blogapp.config;
+
+public class Constants {
+
+    public static final String DEFAULT_PAGE = "0";
+    public static final String PAGE_SIZE = "1";
+    public static final String SORT_BY = "id";
+    public static final String SORT_DIR = "asc";
+
+}

--- a/src/main/java/com/example/blogapp/controllers/PostController.java
+++ b/src/main/java/com/example/blogapp/controllers/PostController.java
@@ -41,6 +41,12 @@ public class PostController {
         return new ResponseEntity<>(postsByCategory, HttpStatus.OK);
     }
 
+    @PutMapping("/posts/{postId}")
+    public ResponseEntity<PostDto> updatePostById(@RequestBody PostDto postDto, @PathVariable("postId") Integer id) {
+        PostDto post = this.postService.updatePost(postDto, id);
+        return new ResponseEntity<>(post, HttpStatus.OK);
+    }
+
     @GetMapping("/posts")
     public ResponseEntity<List<PostDto>> getPosts() {
         List<PostDto> posts = this.postService.getAllPost();
@@ -51,6 +57,12 @@ public class PostController {
     public ResponseEntity<PostDto> getPostById(@PathVariable("postId") Integer id) {
         PostDto post = this.postService.getPostById(id);
         return new ResponseEntity<>(post, HttpStatus.OK);
+    }
+
+    @GetMapping("/posts/search/{keyword}")
+    public ResponseEntity<List<PostDto>> searchPostByKeyword(@PathVariable("keyword") String keyword) {
+        List<PostDto> posts = this.postService.searchPosts(keyword);
+        return new ResponseEntity<>(posts, HttpStatus.OK);
     }
 
     @DeleteMapping("/posts/{postId}")

--- a/src/main/java/com/example/blogapp/controllers/PostController.java
+++ b/src/main/java/com/example/blogapp/controllers/PostController.java
@@ -1,8 +1,10 @@
 package com.example.blogapp.controllers;
 
+import com.example.blogapp.config.Constants;
 import com.example.blogapp.entities.Post;
 import com.example.blogapp.payloads.ApiResponse;
 import com.example.blogapp.payloads.PostDto;
+import com.example.blogapp.payloads.PostResponse;
 import com.example.blogapp.repositories.PostRepo;
 import com.example.blogapp.services.PostService;
 import org.springframework.http.HttpStatus;
@@ -15,7 +17,7 @@ import java.util.List;
 @RequestMapping("/api/")
 public class PostController {
 
-    private PostService postService;
+    private final PostService postService;
 
     public PostController(PostService postService) {
         this.postService = postService;
@@ -59,9 +61,9 @@ public class PostController {
         return new ResponseEntity<>(post, HttpStatus.OK);
     }
 
-    @GetMapping("/posts/search/{keyword}")
-    public ResponseEntity<List<PostDto>> searchPostByKeyword(@PathVariable("keyword") String keyword) {
-        List<PostDto> posts = this.postService.searchPosts(keyword);
+    @GetMapping("/posts/search/{keywords}")
+    public ResponseEntity<List<PostDto>> searchPostByKeywords(@PathVariable("keywords") String keywords) {
+        List<PostDto> posts = this.postService.searchPosts(keywords);
         return new ResponseEntity<>(posts, HttpStatus.OK);
     }
 
@@ -69,5 +71,16 @@ public class PostController {
     public ResponseEntity<ApiResponse> deletePostById(@PathVariable("postId") Integer id) {
         this.postService.deletePost(id);
         return new ResponseEntity<>(new ApiResponse("Post deleted successfully", true), HttpStatus.OK);
+    }
+
+    @GetMapping("/posts/paginated")
+    public ResponseEntity<PostResponse> getPostByPage(
+            @RequestParam(value = "page", defaultValue = Constants.DEFAULT_PAGE, required = false) Integer pageNo,
+            @RequestParam(value = "size", defaultValue = Constants.PAGE_SIZE, required = false) Integer pageSize,
+            @RequestParam(value = "sortBy", defaultValue = Constants.SORT_BY, required = false) String sortBy,
+            @RequestParam(value = "sortDir", defaultValue = Constants.SORT_DIR, required = false) String sortDir) {
+
+        PostResponse postByPage = this.postService.getPostByPage(pageNo, pageSize, sortBy, sortDir);
+        return new ResponseEntity<>(postByPage, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/blogapp/payloads/PostResponse.java
+++ b/src/main/java/com/example/blogapp/payloads/PostResponse.java
@@ -1,0 +1,20 @@
+package com.example.blogapp.payloads;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PostResponse {
+
+    private List<PostDto> content;
+    private int pageNumber;
+    private int pageSize;
+    private int totalElements;
+    private int totalPages;
+    private boolean lastPage;
+}

--- a/src/main/java/com/example/blogapp/repositories/PostRepo.java
+++ b/src/main/java/com/example/blogapp/repositories/PostRepo.java
@@ -11,4 +11,6 @@ public interface PostRepo extends JpaRepository<Post, Integer> {
 
     List<Post> findByUser(User user);
     List<Post> findByCategory(Category category);
+
+    List<Post> findByContentContaining(String content);
 }

--- a/src/main/java/com/example/blogapp/services/FileService.java
+++ b/src/main/java/com/example/blogapp/services/FileService.java
@@ -1,0 +1,14 @@
+package com.example.blogapp.services;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface FileService {
+
+    String uploadImage(String path, MultipartFile file) throws IOException;
+    InputStream getResource(String path, String fileName) throws FileNotFoundException;
+
+}

--- a/src/main/java/com/example/blogapp/services/PostService.java
+++ b/src/main/java/com/example/blogapp/services/PostService.java
@@ -2,6 +2,7 @@ package com.example.blogapp.services;
 
 import com.example.blogapp.entities.Post;
 import com.example.blogapp.payloads.PostDto;
+import com.example.blogapp.payloads.PostResponse;
 
 import java.util.List;
 
@@ -16,6 +17,8 @@ public interface PostService {
     PostDto getPostById(Integer id);
 
     List<PostDto> getAllPost();
+
+    PostResponse getPostByPage(Integer pageNo, Integer pageSize, String sortBy, String sortDir);
 
     List<PostDto> getPostsByCategory(Integer categoryId);
 

--- a/src/main/java/com/example/blogapp/services/impl/FileServiceImpl.java
+++ b/src/main/java/com/example/blogapp/services/impl/FileServiceImpl.java
@@ -1,0 +1,37 @@
+package com.example.blogapp.services.impl;
+
+import com.example.blogapp.services.FileService;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.*;
+import java.util.UUID;
+
+public class FileServiceImpl implements FileService {
+    @Override
+    public String uploadImage(String path, MultipartFile file) throws IOException {
+        // File name
+        String name = file.getOriginalFilename();
+        // abc.png
+
+        // random name generate file
+        String randomId = UUID.randomUUID().toString();
+        String fileName = randomId.concat(name.substring(name.lastIndexOf(".")));
+
+        // Full path
+        String filePath = path + File.separator + fileName;
+
+        // Create folder if not created
+        File f = new File(path);
+        if (!f.exists()) f.mkdir();
+
+        return name;
+    }
+
+    @Override
+    public InputStream getResource(String path, String fileName) throws FileNotFoundException {
+
+        String fullPath = path + File.separator+fileName;
+        // DB logic to return input stream.
+        return new FileInputStream(fullPath);
+    }
+}

--- a/src/main/java/com/example/blogapp/services/impl/PostServiceImpl.java
+++ b/src/main/java/com/example/blogapp/services/impl/PostServiceImpl.java
@@ -4,7 +4,6 @@ import com.example.blogapp.entities.Category;
 import com.example.blogapp.entities.Post;
 import com.example.blogapp.entities.User;
 import com.example.blogapp.exceptions.ResourceNotFoundException;
-import com.example.blogapp.payloads.CategoryDto;
 import com.example.blogapp.payloads.PostDto;
 import com.example.blogapp.repositories.CategoryRepo;
 import com.example.blogapp.repositories.PostRepo;
@@ -15,7 +14,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Random;
 import java.util.stream.Collectors;
 
 @Service
@@ -59,9 +57,10 @@ public class PostServiceImpl implements PostService {
         post.setContent(postDto.getContent());
         post.setTitle(postDto.getTitle());
         post.setImageName(postDto.getImageName());
-        post.setAddedDate(postDto.getAddedDate());
+        post.setAddedDate(new Date());
 
-        return postDto;
+        Post updatedPost = this.postRepo.save(post);
+        return this.mapper.map(updatedPost, PostDto.class);
     }
 
     @Override
@@ -102,6 +101,11 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public List<PostDto> searchPosts(String keyword) {
-        return null;
+        List<Post> posts = this.postRepo.findAll();
+
+        return posts.stream()
+                .filter(post -> post.getContent().contains(keyword))
+                .map(post -> this.mapper.map(post, PostDto.class))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,10 +1,18 @@
 server.port=9191
+
 # DB Configuration
 spring.datasource.url=jdbc:mysql://localhost:3306/insta_blog
 spring.datasource.username=root
 spring.datasource.password=P@ssword786
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
 # create, create-drop, validate, update
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
+
+#File related all configurations
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+
+project.image=images/


### PR DESCRIPTION
Users can provide the following query params to paginate and sort posts response,
page: Indicate page number (default: 0).
size: Indicate page size (default: 1).
sortBy: Indicate sort on the column name (default: id).
sortDir: Indicate sort direction (default: asc).